### PR TITLE
Remove mlibtool

### DIFF
--- a/alternatives.md
+++ b/alternatives.md
@@ -10,8 +10,6 @@ usable with musl.
   Does not require glib.
 - [netbsd-curses] - Drop in replacement for ncurses and ncursesw, ported from
   netbsd. considerably smaller than ncurses.
-- [mlibtool] - Drop-in replacement for libtool. can speed up builds significantly
-  as it's written in C.
 - [slibtool] - Independent reimplementation of slibtool, aiming to maintain compatibility
   and removing features that are unneeded on modern systems.
 - [cDetect] - C replacement for feature detection generally provided by utilities


### PR DESCRIPTION
mlibtool was supposed to be replaced with slibtool in [448adca], but only the link was removed.

[448adca]: https://github.com/somasis/musl-wiki/commit/448adca0822f3eaa831a920c9be71c2d94360006#diff-82fe433785e89dafaac1de4fb6e6a025