### PR TITLE
Add info about missing ldconfig

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -21,6 +21,14 @@ musl's dynamic linker comes with ldd functionality built in. Just create a symli
 from ld-musl-$ARCH.so to /bin/ldd. If the dynamic linker was started as "ldd", it
 will detect that and print the appropriate DSO information.
 
+# Q: Where is `ldconfig`?
+
+There isn't one. You can specify the library search path by creating or editing
+the file `/etc/ld-musl-$ARCH.path` where `$ARCH` is the string identifying your
+architecture (look at `/lib/ld-musl-*.so.1` if uncertain).  Paths can be
+separated by new lines or colons. The environment variables`LD_PRELOAD` and
+`LD_LIBRARY_PATH` are also supported for one-off cases.
+
 # Q: Why is `sys/queue.h` not included?
 
 sys/queue.h is a full library implemented in a header file, and there's no


### PR DESCRIPTION
Library search path configuration is a mystery and afaict, can only be
divined by pouring through the sources.  While more documentation is
needed, this should at least make it easier for people to figure out how
to configure the dynamic library.

I later also found this info in the mailing list as well, but I don't see it documented anywhere. https://www.openwall.com/lists/musl/2015/04/22/4