### PR TITLE
projects-using-musl: Fix Void Linux URL

### DIFF
--- a/projects-using-musl.md
+++ b/projects-using-musl.md
@@ -46,7 +46,7 @@
 [morpheus]: http://git.2f30.org/morpheus/
 [Bedrock Linux]: http://bedrocklinux.org/introduction.html
 [Alpine Linux]: http://alpinelinux.org/
-[void linux]: http://www.voidlinux.eu/
+[Void Linux]: https://voidlinux.org/
 [Exherbo]: http://www.exherbo.org/
 [CLFS-announcement]: http://openwall.com/lists/musl/2013/10/16/1
 [oasis]: https://github.com/michaelforney/oasis


### PR DESCRIPTION
Current project link points to a forum with no noticeable relation to the project. As well as having undesirable links spared throughout. This commit points it to the correct project page. 