### PR TITLE
Add mussel

### DIFF
--- a/projects-using-musl.md
+++ b/projects-using-musl.md
@@ -123,6 +123,7 @@ Third-party projects using or building on musl:
   code is from musl.
 - [docker-muslbase] minimal musl-based docker container
 - [buildroot] toolchain has musl libc option
+- [mussel] The shortest and fastest script to build working cross compilers targeting musl libc
 - [seL4] seL4 kernel ships with musl
 - [NodeOS] linux with Node.js as userspace
 - [Rust] is a programming language with musl supported as a cross-compilation
@@ -143,6 +144,7 @@ Third-party projects using or building on musl:
 [Mirage OS]: http://www.openmirage.org/
 [docker-muslbase]: https://github.com/mwcampbell/docker-muslbase
 [buildroot]: http://buildroot.org/
+[mussel]: https://github.com/firasuke/mussel
 [seL4]: https://github.com/seL4/libmuslc
 [NodeOS]: https://github.com/NodeOS/NodeOS
 [Rust]: http://www.rust-lang.org/


### PR DESCRIPTION
mussel is the shortest and fastest script available today to build working cross compilers that target musl libc.

## Features
1. **Up-to-date**: uses latest available upstream sources for packages
2. **Fast**: probably the fastest script around to build a cross compiler
   targetting musl libc, also it's written entirely in POSIX DASH
3. **Short**: has the least amount of steps (see below) required to build a
   cross compiler targetting musl libc (even less than
   [musl-cross-make](https://github.com/richfelker/musl-cross-make))
4. **Small**: all installation steps use `install-strip` when applicable
5. **Simple**: easy to read, modify and extend
6. **POSIX Compliant**: written entirely in POSIX DASH
7. **Well Documented**: the script has comments (that are considered state of
   the art information) all over the place explaining what is being done and why