### PR TITLE
projects-using-musl: add adelie linux

### DIFF
--- a/projects-using-musl.md
+++ b/projects-using-musl.md
@@ -50,6 +50,7 @@
 - [solyste] - statically linked linux distribution targetting embedded hardware
 and various architectures
 - [glaucus] - An independent, open-source, general-purpose, bleeding-edge, rolling-release, source-based Linux® distribution based on musl libc and toybox, built from scratch around the suckless philosophy without sacrificing convenience.
+- [Adélie Linux] - A completely independent, Libre operating system with focus on reliability, security, compatibility, portability, and usability.
 
 [sabotage]: http://sabo.xyz/
 [bootstrap-linux]: https://github.com/pikhq/bootstrap-linux
@@ -72,6 +73,7 @@ and various architectures
 [Abyss]: https://abyss.run
 [solyste]: https://framagit.org/Ypnose/solyste
 [glaucus]: https://www.glaucuslinux.org/
+[Adélie Linux]: https://adelielinux.org
 
 # Linux distros that plan to switch to musl
 


### PR DESCRIPTION
Adelie Linux is a completely independent, Libre operating system
based on the Linux kernel and musl runtime library.

Signed-off-by: John Ogness <john.ogness@linutronix.de>