### PR TITLE
Fix formatting

### DIFF
--- a/functional-differences-from-glibc.md
+++ b/functional-differences-from-glibc.md
@@ -361,10 +361,11 @@ difference prevented the use of larger packets produced by protocols such as
 DNSSEC and DKIM.
 
 musl also does not implement the following glibc bugs:
-* When the `hints` parameter for `getaddrinfo` is unset, glibc sets the
+
+- When the `hints` parameter for `getaddrinfo` is unset, glibc sets the
   `ai_protocol` field, which is
   [non-complaint](https://github.com/libuv/libuv/issues/2225#issuecomment-765808228).
-* When `getaddrinfo` is called with `AF_UNSPEC`, glibc returns a result
+- When `getaddrinfo` is called with `AF_UNSPEC`, glibc returns a result
   even if one of the address families returns `ServFail`.  This is a bug
   (glibc #27929) and may undermine DNSSEC.
 


### PR DESCRIPTION
Missing blank line caused list not be recognized.

Although `*` (star) would be working for markdown list, convert it to `-` (dash) because other lists on the page use it.
